### PR TITLE
docs(install): add the TanStack Start guide

### DIFF
--- a/apps/web/lib/docs-frameworks.ts
+++ b/apps/web/lib/docs-frameworks.ts
@@ -6,8 +6,9 @@ import { COLLECTOR_BASE_URL } from "@/lib/api";
  * One page template renders all of them (`app/docs/install/[framework]`),
  * so a guide is a list of steps here rather than a hand-built page. The
  * list mirrors what `oa init` detects (`apps/cli/src/init/detect.ts`) plus
- * the hosted-platform guides the CLI cannot reach (Webflow, Shopify) — the
- * snippet is the same everywhere; only the file it goes into changes.
+ * the guides the CLI does not reach — hosted platforms (Webflow, Shopify) and
+ * frameworks it has no injector for yet (TanStack Start) — the snippet is the
+ * same everywhere; only the file it goes into changes.
  *
  * `SNIPPET` is the placeholder-key form of the tracker tag from
  * `docs/frontend/tracker_snippet.md`; every claim in the steps is that
@@ -88,6 +89,54 @@ export const DOC_FRAMEWORKS: DocFramework[] = [
       },
       {
         text: "Client-side navigation is tracked automatically: the script patches the history API, so route changes count as pageviews with no extra code.",
+      },
+      VERIFY_STEP,
+    ],
+  },
+  {
+    slug: "tanstack-start",
+    name: "TanStack Start",
+    cliDetects: false,
+    steps: [
+      {
+        text: "TanStack Start has no HTML shell; the document head is declared on the root route. Add the script to the scripts array returned by head() in your root route, next to your meta and links.",
+        code: `import { createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [{ charSet: "utf-8" }],
+    scripts: [
+      {
+        src: "${COLLECTOR_BASE_URL}/oa.js",
+        async: true,
+        "data-key": "YOUR_TRACKING_KEY",
+        "data-collector": "${COLLECTOR_BASE_URL}",
+      },
+    ],
+  }),
+  shellComponent: RootDocument,
+});`,
+        caption: "src/routes/__root.tsx",
+      },
+      {
+        text: "Make sure <HeadContent /> is rendered inside <head> in your root document; it is what turns the head() entries into tags. Every Start starter already has it.",
+        code: `function RootDocument({ children }) {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  );
+}`,
+        caption: "src/routes/__root.tsx",
+      },
+      {
+        text: "Router navigation is tracked automatically; the root route stays mounted across client-side transitions, so the tag loads once and follows every route change.",
       },
       VERIFY_STEP,
     ],

--- a/apps/web/lib/docs-frameworks.ts
+++ b/apps/web/lib/docs-frameworks.ts
@@ -99,7 +99,7 @@ export const DOC_FRAMEWORKS: DocFramework[] = [
     cliDetects: false,
     steps: [
       {
-        text: "TanStack Start has no HTML shell; the document head is declared on the root route. Add the script to the scripts array returned by head() in your root route, next to your meta and links.",
+        text: "TanStack Start has no static HTML file; the document shell and its head are declared on the root route. Add the script to the scripts array returned by head() there, next to your meta and links.",
         code: `import { createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
 
 export const Route = createRootRoute({


### PR DESCRIPTION
**What this changes, and why**

There was no install guide for TanStack Start, and neither neighbouring guide fits it: Start has no `index.html` (so the React (Vite / CRA) page is wrong for it) and its document head is the root route's `head()` option, not a `<head>` in a layout (so the Next.js page doesn't transfer either). This adds one `DOC_FRAMEWORKS` entry — the docs are data, so it's a new list item, not a new page — placed after Next.js. The steps: the script as a `scripts` entry in `head()` of `src/routes/__root.tsx`, the `<HeadContent />` reminder, and the auto-tracked-navigation note, plus the shared verify step.

It's marked `cliDetects: false` for now (same branch of the page template Webflow and Shopify use). `oa init` detection and an injector are a separate, follow-up change so this one stays a pure docs fix.

**How you know it works**

- Checked the shape against TanStack's own source, not memory: `createRootRoute({ head: () => ({ scripts: [...] }) })` from `@tanstack/react-router` (the `start-basic` example and `build-from-scratch` guide); `Asset.tsx` types script entries as `[key: string]: string | boolean` and spreads them onto `<script>` on the server / `setAttribute` on the client, so `async` and `data-*` pass through; the router's document-head guide uses an external analytics `src` as its `scripts` example.
- Checked step 3's claim ("route changes tracked automatically") against both sides: the tracker patches `history.pushState`/`replaceState` and listens to `popstate`; TanStack's history `flush()` calls the *live* `window.history.pushState` (it keeps the original only for `destroy()`), so the async-loaded patch sees every transition. Same-URL writes (Start's startup `replaceState` key stamp) are deduped by the tracker's `lastPageUrl` check.
- Rendered locally: `/docs/install/tanstack-start` returns 200 with the right title, `/docs/install` and the sidebar list it after Next.js.
- `pnpm run verify` passes.

**Anything a reviewer should look at twice**

- Placement after Next.js is a judgment call about prominence — the list wasn't strictly grouped by runtime before (Remix and Gatsby sit further down). Happy to move it.
- The header comment in `docs-frameworks.ts` is reworded to say the list is "detection + guides the CLI does not reach", since TanStack Start is now the one undetected non-hosted entry.

---

- [x] `pnpm run verify` passes locally
- [ ] API surface changes start in `packages/contracts/openapi/openapi.yaml` and `pnpm run contracts:generate` was re-run — n/a, no API change
- [ ] Tracker changes still fit the byte budget (`pnpm run tracker:build`) — n/a, no tracker change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added TanStack Start to the framework installation guides not automatically detected by the CLI.
  * Documented root-route `head()` configuration and `HeadContent` rendering requirements.
  * Added guidance for automatic navigation tracking and deployment verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->