### PR TITLE
feat(cli): oa init detects TanStack Start and writes its root route

### DIFF
--- a/apps/cli/src/init/detect.ts
+++ b/apps/cli/src/init/detect.ts
@@ -29,6 +29,7 @@ export type FrameworkId =
   | 'nuxt'
   | 'sveltekit'
   | 'remix'
+  | 'tanstack-start'
   | 'astro'
   | 'gatsby'
   | 'wordpress'
@@ -42,6 +43,7 @@ export const FRAMEWORKS: readonly Framework[] = [
   { id: 'nuxt', name: 'Nuxt' },
   { id: 'sveltekit', name: 'SvelteKit' },
   { id: 'remix', name: 'Remix' },
+  { id: 'tanstack-start', name: 'TanStack Start' },
   { id: 'astro', name: 'Astro' },
   { id: 'gatsby', name: 'Gatsby' },
   { id: 'wordpress', name: 'WordPress' },
@@ -107,6 +109,14 @@ export function detectFramework(cwd: string): Framework | null {
 
   if (hasConfigFile(cwd, 'remix.config') || hasDependency(pkg, '@remix-run/react')) {
     return frameworkById('remix') ?? null
+  }
+
+  // Start is a Vite app with `react` in its dependencies, so it has to be
+  // asked about before the generic Vite-plus-React question below. The Solid
+  // flavour keeps the same root-route file and `head()` shape, so one answer
+  // covers both.
+  if (hasDependency(pkg, '@tanstack/react-start') || hasDependency(pkg, '@tanstack/solid-start')) {
+    return frameworkById('tanstack-start') ?? null
   }
 
   if (hasConfigFile(cwd, 'astro.config') || hasDependency(pkg, 'astro')) {

--- a/apps/cli/src/init/injectors.ts
+++ b/apps/cli/src/init/injectors.ts
@@ -267,6 +267,88 @@ function injectRemix(ctx: InjectContext): InjectResult {
   return { file: file.rel, alreadyInstalled: false }
 }
 
+/**
+ * TanStack Start has no static HTML file: the document shell and its head are
+ * the root route's, the head as its `head()` option rendered by `<HeadContent />`. The tag becomes an entry in
+ * that option's `scripts` array — added to the array when there is one, to the
+ * `head()` object when there is not, and as a whole `head()` when the root
+ * route declares none. Text edits anchored on the file's own indentation, as
+ * the Nuxt injector does; no parser.
+ */
+function injectTanStackStart(ctx: InjectContext): InjectResult {
+  const file = findFile(
+    ctx.cwd,
+    ['src/routes/__root', 'app/routes/__root'].flatMap((base) =>
+      ['.tsx', '.jsx', '.js', '.ts'].map((ext) => base + ext),
+    ),
+  )
+  if (!file) {
+    throw new InjectError(
+      'src/routes/__root.tsx not found. Run this from the root of your TanStack Start project.',
+    )
+  }
+
+  let content = readFile(file.abs)
+  if (isAlreadyInstalled(content)) return { file: file.rel, alreadyInstalled: true }
+
+  const scriptEntry = (indent: string): string =>
+    [
+      `${indent}{`,
+      `${indent}  src: '${ctx.collector}/oa.js',`,
+      `${indent}  'data-key': '${ctx.key}',`,
+      `${indent}  'data-collector': '${ctx.collector}',`,
+      `${indent}  async: true,`,
+      `${indent}},`,
+    ].join('\n')
+
+  // `head: () => ({` — the option as every Start starter writes it, with or
+  // without a parameter, with or without `async`.
+  const head = content.match(/^([ \t]*)head\s*:\s*(?:async\s*)?\([^)]*\)\s*=>\s*\(\s*\{/m)
+  if (head && head.index !== undefined) {
+    const headIndent = head[1] ?? ''
+    const afterHead = head.index + head[0].length
+    const scripts = content.slice(afterHead).match(/^([ \t]*)scripts\s*:\s*\[/m)
+    if (scripts && scripts.index !== undefined) {
+      // The array exists: the tag joins it as the first entry.
+      const at = afterHead + scripts.index + scripts[0].length
+      const itemIndent = `${scripts[1] ?? ''}  `
+      content = `${content.slice(0, at)}\n${scriptEntry(itemIndent)}${content.slice(at)}`
+    } else {
+      // A head() without scripts: the array opens the returned object.
+      const keyIndent = `${headIndent}  `
+      const block = [
+        '',
+        `${keyIndent}scripts: [`,
+        scriptEntry(`${keyIndent}  `),
+        `${keyIndent}],`,
+      ].join('\n')
+      content = `${content.slice(0, afterHead)}${block}${content.slice(afterHead)}`
+    }
+  } else {
+    // No head() at all: one is added as the first root-route option.
+    const anchor = content.indexOf('createRootRoute')
+    if (anchor === -1) {
+      throw new InjectError(`Could not find createRootRoute in ${file.rel}.`)
+    }
+    const brace = content.indexOf('({', anchor)
+    if (brace === -1) {
+      throw new InjectError(`Could not find the root route options in ${file.rel}.`)
+    }
+    const block = [
+      '',
+      '  head: () => ({',
+      '    scripts: [',
+      scriptEntry('      '),
+      '    ],',
+      '  }),',
+    ].join('\n')
+    content = `${content.slice(0, brace + 2)}${block}${content.slice(brace + 2)}`
+  }
+
+  writeFile(file.abs, content)
+  return { file: file.rel, alreadyInstalled: false }
+}
+
 function injectGatsby(ctx: InjectContext): InjectResult {
   const snippet = [
     '// Open Analytics',
@@ -380,6 +462,8 @@ export function inject(framework: FrameworkId, ctx: InjectContext): InjectResult
       return injectSvelteKit(ctx)
     case 'remix':
       return injectRemix(ctx)
+    case 'tanstack-start':
+      return injectTanStackStart(ctx)
     case 'astro':
       return injectAstro(ctx)
     case 'gatsby':

--- a/apps/cli/src/init/injectors.ts
+++ b/apps/cli/src/init/injectors.ts
@@ -419,6 +419,16 @@ function injectTanStackStart(ctx: InjectContext): InjectResult {
       ].join('\n')
       content = `${content.slice(0, afterHead)}${block}${content.slice(afterHead)}`
     }
+  } else if (/^[ \t]*(?:async\s+)?head\s*[:(]/m.test(optionsBody)) {
+    // A head() the arrow-object edit cannot see — method shorthand, a block
+    // body, a named function — is a refusal, not a fall-through: adding a
+    // second `head:` would let the person's own win and the script silently
+    // never load, which is the one outcome an installer must not have.
+    throw new InjectError(
+      `head() in ${file.rel} is not written as \`head: () => ({ … })\`, which is the only form ` +
+        'the installer edits. Add the script entry by hand: the TanStack Start page under ' +
+        'Installation in the docs shows where.',
+    )
   } else {
     // No head() at all: one is added as the first root-route option.
     const block = [

--- a/apps/cli/src/init/injectors.ts
+++ b/apps/cli/src/init/injectors.ts
@@ -268,6 +268,89 @@ function injectRemix(ctx: InjectContext): InjectResult {
 }
 
 /**
+ * Index of the `}` that closes the `{` at `open`, stepping over string and
+ * template literals and comments so a brace inside `'{'` or `// {` does not
+ * count. `-1` when nothing closes it. Enough of a scanner for an options
+ * object; not a parser, and not trying to be one.
+ */
+function closingBrace(content: string, open: number): number {
+  let depth = 0
+  for (let i = open; i < content.length; i += 1) {
+    const ch = content[i]
+    const next = content[i + 1]
+    if (ch === '/' && next === '/') {
+      const eol = content.indexOf('\n', i)
+      if (eol === -1) return -1
+      i = eol
+      continue
+    }
+    if (ch === '/' && next === '*') {
+      const end = content.indexOf('*/', i + 2)
+      if (end === -1) return -1
+      i = end + 1
+      continue
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      const end = closingQuote(content, i)
+      if (end === -1) return -1
+      i = end
+      continue
+    }
+    if (ch === '{') depth += 1
+    else if (ch === '}') {
+      depth -= 1
+      if (depth === 0) return i
+    }
+  }
+  return -1
+}
+
+/** The index of the quote ending the literal that opens at `start`; a `'` or
+ * `"` left open at the end of its line (JSX text, say) ends there instead. */
+function closingQuote(content: string, start: number): number {
+  const quote = content[start]
+  for (let i = start + 1; i < content.length; i += 1) {
+    const ch = content[i]
+    if (ch === '\\') {
+      i += 1
+      continue
+    }
+    if (ch === quote) return i
+    if (quote !== '`' && ch === '\n') return i
+  }
+  return -1
+}
+
+/**
+ * The root route's options object: `open` is its `{`, `close` its `}`. Found
+ * from the `Route = createRootRoute…` declaration (file-based routing requires
+ * that export), falling back to the first `createRootRoute` that is not on an
+ * import line, then the first `({` after it — which, for
+ * `createRootRouteWithContext<T>()({`, is the second call's.
+ */
+function rootRouteOptions(content: string): { open: number; close: number } | null {
+  const identifier = /\bcreateRootRoute(?:WithContext)?\b/g
+  let anchor = -1
+  const declared = content.match(/\bRoute\s*=\s*createRootRoute(?:WithContext)?\b/)
+  if (declared?.index !== undefined) {
+    anchor = declared.index + declared[0].length
+  } else {
+    for (const match of content.matchAll(identifier)) {
+      const lineStart = content.lastIndexOf('\n', match.index) + 1
+      if (content.slice(lineStart, match.index).trimStart().startsWith('import')) continue
+      anchor = match.index + match[0].length
+      break
+    }
+  }
+  if (anchor === -1) return null
+  const open = content.indexOf('({', anchor)
+  if (open === -1) return null
+  const close = closingBrace(content, open + 1)
+  if (close === -1) return null
+  return { open: open + 1, close }
+}
+
+/**
  * TanStack Start has no static HTML file: the document shell and its head are
  * the root route's, the head as its `head()` option rendered by `<HeadContent />`. The tag becomes an entry in
  * that option's `scripts` array — added to the array when there is one, to the
@@ -301,13 +384,25 @@ function injectTanStackStart(ctx: InjectContext): InjectResult {
       `${indent}},`,
     ].join('\n')
 
+  // Every search is scoped to the root route's own options: a helper above it
+  // with a `head:` of its own, or an earlier `({` call, must not catch the edit.
+  const options = rootRouteOptions(content)
+  if (!options) {
+    throw new InjectError(`Could not find the createRootRoute options object in ${file.rel}.`)
+  }
+  const optionsBody = content.slice(options.open, options.close)
+
   // `head: () => ({` — the option as every Start starter writes it, with or
   // without a parameter, with or without `async`.
-  const head = content.match(/^([ \t]*)head\s*:\s*(?:async\s*)?\([^)]*\)\s*=>\s*\(\s*\{/m)
+  const head = optionsBody.match(/^([ \t]*)head\s*:\s*(?:async\s*)?\([^)]*\)\s*=>\s*\(\s*\{/m)
   if (head && head.index !== undefined) {
     const headIndent = head[1] ?? ''
-    const afterHead = head.index + head[0].length
-    const scripts = content.slice(afterHead).match(/^([ \t]*)scripts\s*:\s*\[/m)
+    const afterHead = options.open + head.index + head[0].length
+    const headClose = closingBrace(content, afterHead - 1)
+    if (headClose === -1) {
+      throw new InjectError(`Could not find the end of head() in ${file.rel}.`)
+    }
+    const scripts = content.slice(afterHead, headClose).match(/^([ \t]*)scripts\s*:\s*\[/m)
     if (scripts && scripts.index !== undefined) {
       // The array exists: the tag joins it as the first entry.
       const at = afterHead + scripts.index + scripts[0].length
@@ -326,14 +421,6 @@ function injectTanStackStart(ctx: InjectContext): InjectResult {
     }
   } else {
     // No head() at all: one is added as the first root-route option.
-    const anchor = content.indexOf('createRootRoute')
-    if (anchor === -1) {
-      throw new InjectError(`Could not find createRootRoute in ${file.rel}.`)
-    }
-    const brace = content.indexOf('({', anchor)
-    if (brace === -1) {
-      throw new InjectError(`Could not find the root route options in ${file.rel}.`)
-    }
     const block = [
       '',
       '  head: () => ({',
@@ -342,7 +429,7 @@ function injectTanStackStart(ctx: InjectContext): InjectResult {
       '    ],',
       '  }),',
     ].join('\n')
-    content = `${content.slice(0, brace + 2)}${block}${content.slice(brace + 2)}`
+    content = `${content.slice(0, options.open + 1)}${block}${content.slice(options.open + 1)}`
   }
 
   writeFile(file.abs, content)

--- a/apps/web/app/docs/cli/page.tsx
+++ b/apps/web/app/docs/cli/page.tsx
@@ -33,8 +33,9 @@ npx getopen <command>`}</DocCode>
 # non-interactive (CI, scripts):
 npx getopen init --key oa_pk_… --framework nextjs-app --yes`}</DocCode>
         <p>
-          Detected frameworks: Next.js (App and Pages Router), React, Vue,
-          Nuxt, SvelteKit, Remix, Astro, Gatsby, WordPress and plain HTML.
+          Detected frameworks: Next.js (App and Pages Router), TanStack
+          Start, React, Vue, Nuxt, SvelteKit, Remix, Astro, Gatsby,
+          WordPress and plain HTML.
           The <DocLink slug="install">installation guides</DocLink> show
           what it writes, per framework.
         </p>

--- a/apps/web/lib/docs-frameworks.ts
+++ b/apps/web/lib/docs-frameworks.ts
@@ -6,9 +6,8 @@ import { COLLECTOR_BASE_URL } from "@/lib/api";
  * One page template renders all of them (`app/docs/install/[framework]`),
  * so a guide is a list of steps here rather than a hand-built page. The
  * list mirrors what `oa init` detects (`apps/cli/src/init/detect.ts`) plus
- * the guides the CLI does not reach — hosted platforms (Webflow, Shopify) and
- * frameworks it has no injector for yet (TanStack Start) — the snippet is the
- * same everywhere; only the file it goes into changes.
+ * the hosted-platform guides the CLI cannot reach (Webflow, Shopify) — the
+ * snippet is the same everywhere; only the file it goes into changes.
  *
  * `SNIPPET` is the placeholder-key form of the tracker tag from
  * `docs/frontend/tracker_snippet.md`; every claim in the steps is that
@@ -96,7 +95,7 @@ export const DOC_FRAMEWORKS: DocFramework[] = [
   {
     slug: "tanstack-start",
     name: "TanStack Start",
-    cliDetects: false,
+    cliDetects: true,
     steps: [
       {
         text: "TanStack Start has no static HTML file; the document shell and its head are declared on the root route. Add the script to the scripts array returned by head() there, next to your meta and links.",

--- a/apps/web/lib/docs-frameworks.ts
+++ b/apps/web/lib/docs-frameworks.ts
@@ -98,7 +98,7 @@ export const DOC_FRAMEWORKS: DocFramework[] = [
     cliDetects: true,
     steps: [
       {
-        text: "TanStack Start has no static HTML file; the document shell and its head are declared on the root route. Add the script to the scripts array returned by head() there, next to your meta and links.",
+        text: "TanStack Start has no static HTML file; the document shell and its head are declared on the root route. Add the script to the scripts array returned by head() there, next to your meta and links. On Solid Start the shape is the same; the import comes from @tanstack/solid-router.",
         code: `import { createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
 
 export const Route = createRootRoute({

--- a/tests/unit/cli-init-tanstack-start.test.ts
+++ b/tests/unit/cli-init-tanstack-start.test.ts
@@ -102,6 +102,35 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 })
 `
 
+/** A helper with a head() and a scripts array of its own, declared above the
+ * root route — the thing a file-wide search would edit by mistake. */
+const ROOT_AFTER_HELPER_HEAD = `import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
+
+const fallback = {
+  head: () => ({
+    scripts: [{ src: '/helper.js' }],
+  }),
+}
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [{ charSet: 'utf-8' }],
+  }),
+  component: RootComponent,
+})
+`
+
+/** An earlier \`({\` call (a destructuring arrow) above a root route that has
+ * no head() — where "the first \`({\` after createRootRoute" used to land. */
+const ROOT_AFTER_PAREN_BRACE = `import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
+
+const seo = ({ title }: { title: string }) => [{ title }]
+
+export const Route = createRootRoute({
+  component: RootComponent,
+})
+`
+
 describe('detectFramework on a TanStack Start project', () => {
   it('answers tanstack-start from the @tanstack/react-start dependency', () => {
     writeProject({
@@ -177,6 +206,30 @@ describe('inject on a TanStack Start root route', () => {
     expect(written.indexOf('head:')).toBeLessThan(written.indexOf('component:'))
   })
 
+  it('edits the root route, not a helper above it that also has a head()', () => {
+    writeProject({ 'src/routes/__root.tsx': ROOT_AFTER_HELPER_HEAD })
+
+    inject('tanstack-start', ctx())
+
+    const written = readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')
+    expect(syntaxErrors(written)).toEqual([])
+    // The helper keeps its one-entry array; ours lands inside createRootRoute's head().
+    expect(written).toContain("scripts: [{ src: '/helper.js' }],")
+    expect(written.indexOf('/oa.js')).toBeGreaterThan(written.indexOf('createRootRoute({'))
+    expect(written.match(/\/oa\.js/g)).toHaveLength(1)
+  })
+
+  it('adds head() to the root route, not at an earlier ({ call', () => {
+    writeProject({ 'src/routes/__root.tsx': ROOT_AFTER_PAREN_BRACE })
+
+    inject('tanstack-start', ctx())
+
+    const written = readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')
+    expect(syntaxErrors(written)).toEqual([])
+    expect(written).toContain('const seo = ({ title }: { title: string }) => [{ title }]')
+    expect(written).toMatch(/createRootRoute\(\{\n {2}head: \(\) => \(\{\n {4}scripts: \[/)
+  })
+
   it('finds the root route under app/routes as well', () => {
     writeProject({ 'app/routes/__root.jsx': ROOT_WITHOUT_SCRIPTS })
 
@@ -208,6 +261,8 @@ describe('inject on a TanStack Start root route', () => {
   it('refuses a root route it cannot anchor in, rather than guessing', () => {
     writeProject({ 'src/routes/__root.tsx': 'export const Route = somethingElse({})\n' })
 
-    expect(() => inject('tanstack-start', ctx())).toThrow(/Could not find createRootRoute/)
+    expect(() => inject('tanstack-start', ctx())).toThrow(
+      /Could not find the createRootRoute options object/,
+    )
   })
 })

--- a/tests/unit/cli-init-tanstack-start.test.ts
+++ b/tests/unit/cli-init-tanstack-start.test.ts
@@ -131,6 +131,17 @@ export const Route = createRootRoute({
 })
 `
 
+/** head() as method shorthand: the form the arrow-object edit cannot see. */
+const ROOT_WITH_METHOD_HEAD = `import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head() {
+    return { meta: [{ charSet: 'utf-8' }] }
+  },
+  component: RootComponent,
+})
+`
+
 describe('detectFramework on a TanStack Start project', () => {
   it('answers tanstack-start from the @tanstack/react-start dependency', () => {
     writeProject({
@@ -256,6 +267,39 @@ describe('inject on a TanStack Start root route', () => {
 
     expect(() => inject('tanstack-start', ctx())).toThrow(InjectError)
     expect(() => inject('tanstack-start', ctx())).toThrow(/src\/routes\/__root\.tsx not found/)
+  })
+
+  it('refuses a head() it cannot edit rather than adding a second one', () => {
+    // A second `head:` would be shadowed by the person's own and the script
+    // would silently never load — the one outcome an installer must not have.
+    writeProject({ 'src/routes/__root.tsx': ROOT_WITH_METHOD_HEAD })
+
+    expect(() => inject('tanstack-start', ctx())).toThrow(InjectError)
+    expect(() => inject('tanstack-start', ctx())).toThrow(
+      /head\(\) in src\/routes\/__root\.tsx is not written as/,
+    )
+    expect(readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')).toBe(ROOT_WITH_METHOD_HEAD)
+  })
+
+  it('refuses a head referenced by name or written as a block body, too', () => {
+    const forms = [
+      'head: buildHead,',
+      'head: () => {\n    return {}\n  },',
+      'head: async () => {\n    return {}\n  },',
+    ]
+    for (const head of forms) {
+      writeProject({
+        'src/routes/__root.tsx': [
+          "import { createRootRoute } from '@tanstack/react-router'",
+          'export const Route = createRootRoute({',
+          `  ${head}`,
+          '  component: RootComponent,',
+          '})',
+          '',
+        ].join('\n'),
+      })
+      expect(() => inject('tanstack-start', ctx())).toThrow(/is not written as/)
+    }
   })
 
   it('refuses a root route it cannot anchor in, rather than guessing', () => {

--- a/tests/unit/cli-init-tanstack-start.test.ts
+++ b/tests/unit/cli-init-tanstack-start.test.ts
@@ -1,0 +1,213 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import ts from 'typescript'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { detectFramework } from '../../apps/cli/src/init/detect.ts'
+import { inject, InjectError } from '../../apps/cli/src/init/injectors.ts'
+
+/**
+ * `oa init` on a TanStack Start project.
+ *
+ * Start has no HTML shell; the injector edits the root route's `head()` by
+ * text, anchored on the file's own indentation. The edit is what is pinned
+ * here, in the three shapes a root route comes in (a `scripts` array already
+ * there, a `head()` without one, no `head()` at all), plus the two rules every
+ * injector keeps: idempotent on `/oa.js`, and an error that names the file it
+ * looked for. Every written file is also run through the TypeScript parser,
+ * because a text edit that lands in the wrong brace is a syntax error the
+ * person only meets when their build breaks.
+ */
+
+const KEY = 'oa_pk_test'
+const COLLECTOR = 'https://c.example.com'
+
+let cwd: string
+
+beforeEach(() => {
+  cwd = mkdtempSync(join(tmpdir(), 'oa-init-tanstack-'))
+})
+
+afterEach(() => {
+  rmSync(cwd, { recursive: true, force: true })
+})
+
+function writeProject(files: Record<string, string>): void {
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(cwd, rel)
+    mkdirSync(join(abs, '..'), { recursive: true })
+    writeFileSync(abs, content, 'utf8')
+  }
+}
+
+function pkg(deps: Record<string, string>): string {
+  return JSON.stringify({ name: 'fixture', dependencies: deps })
+}
+
+/** The parser's verdict on a written root route: no syntax diagnostics. */
+function syntaxErrors(source: string): string[] {
+  const result = ts.transpileModule(source, {
+    reportDiagnostics: true,
+    fileName: '__root.tsx',
+    compilerOptions: { jsx: ts.JsxEmit.Preserve, target: ts.ScriptTarget.ES2022 },
+  })
+  return (result.diagnostics ?? []).map((d) => ts.flattenDiagnosticMessageText(d.messageText, '\n'))
+}
+
+const ROOT_WITH_SCRIPTS = `import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [{ charSet: 'utf-8' }],
+    scripts: [
+      {
+        src: '/customScript.js',
+        type: 'text/javascript',
+      },
+    ],
+  }),
+  shellComponent: RootDocument,
+})
+
+function RootDocument({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  )
+}
+`
+
+const ROOT_WITHOUT_SCRIPTS = `import { HeadContent, Scripts, createRootRoute } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  head: () => ({
+    meta: [{ charSet: 'utf-8' }, { title: 'Starter' }],
+  }),
+  component: RootComponent,
+})
+`
+
+const ROOT_WITHOUT_HEAD = `import { HeadContent, Scripts, createRootRouteWithContext } from '@tanstack/react-router'
+import type { QueryClient } from '@tanstack/react-query'
+
+export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
+  component: RootComponent,
+})
+`
+
+describe('detectFramework on a TanStack Start project', () => {
+  it('answers tanstack-start from the @tanstack/react-start dependency', () => {
+    writeProject({
+      'package.json': pkg({ '@tanstack/react-start': '^1.0.0', react: '^19.0.0' }),
+      'vite.config.ts': 'export default {}',
+    })
+    expect(detectFramework(cwd)?.id).toBe('tanstack-start')
+  })
+
+  it('wins over the generic Vite-plus-React answer', () => {
+    // The same folder without Start is a plain React app: the order of the
+    // questions is what keeps a Start project out of that bucket.
+    writeProject({
+      'package.json': pkg({ react: '^19.0.0' }),
+      'vite.config.ts': 'export default {}',
+      'index.html': '<html><head></head></html>',
+    })
+    expect(detectFramework(cwd)?.id).toBe('react')
+  })
+
+  it('covers the Solid flavour too', () => {
+    writeProject({ 'package.json': pkg({ '@tanstack/solid-start': '^1.0.0' }) })
+    expect(detectFramework(cwd)?.id).toBe('tanstack-start')
+  })
+})
+
+describe('inject on a TanStack Start root route', () => {
+  const ctx = () => ({ cwd, key: KEY, collector: COLLECTOR })
+
+  it('joins an existing scripts array as its first entry', () => {
+    writeProject({ 'src/routes/__root.tsx': ROOT_WITH_SCRIPTS })
+
+    const result = inject('tanstack-start', ctx())
+
+    expect(result).toEqual({ file: 'src/routes/__root.tsx', alreadyInstalled: false })
+    const written = readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')
+    expect(syntaxErrors(written)).toEqual([])
+    expect(written).toContain(`src: '${COLLECTOR}/oa.js'`)
+    expect(written).toContain(`'data-key': '${KEY}'`)
+    expect(written).toContain(`'data-collector': '${COLLECTOR}'`)
+    expect(written).toContain('async: true')
+    // Ours comes first, the project's own script stays, nothing else moves.
+    expect(written.indexOf('/oa.js')).toBeLessThan(written.indexOf('/customScript.js'))
+    expect(written).toContain("meta: [{ charSet: 'utf-8' }]")
+    expect(written).toMatch(
+      / {4}scripts: \[\n {6}\{\n {8}src: 'https:\/\/c\.example\.com\/oa\.js',/,
+    )
+  })
+
+  it('adds a scripts array to a head() that has none', () => {
+    writeProject({ 'src/routes/__root.tsx': ROOT_WITHOUT_SCRIPTS })
+
+    inject('tanstack-start', ctx())
+
+    const written = readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')
+    expect(syntaxErrors(written)).toEqual([])
+    expect(written).toMatch(/head: \(\) => \(\{\n {4}scripts: \[\n {6}\{\n {8}src: /)
+    expect(written).toContain("{ title: 'Starter' }")
+  })
+
+  it('adds a whole head() to a root route that declares none', () => {
+    writeProject({ 'src/routes/__root.tsx': ROOT_WITHOUT_HEAD })
+
+    inject('tanstack-start', ctx())
+
+    const written = readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')
+    expect(syntaxErrors(written)).toEqual([])
+    // createRootRouteWithContext<T>()({ — the options object is the second
+    // call's, and head() lands inside it, before the project's own options.
+    expect(written).toMatch(
+      /createRootRouteWithContext<\{ queryClient: QueryClient \}>\(\)\(\{\n {2}head: \(\) => \(\{\n {4}scripts: \[/,
+    )
+    expect(written.indexOf('head:')).toBeLessThan(written.indexOf('component:'))
+  })
+
+  it('finds the root route under app/routes as well', () => {
+    writeProject({ 'app/routes/__root.jsx': ROOT_WITHOUT_SCRIPTS })
+
+    expect(inject('tanstack-start', ctx())).toEqual({
+      file: 'app/routes/__root.jsx',
+      alreadyInstalled: false,
+    })
+  })
+
+  it('is idempotent: a second run leaves the file alone', () => {
+    writeProject({ 'src/routes/__root.tsx': ROOT_WITH_SCRIPTS })
+
+    inject('tanstack-start', ctx())
+    const once = readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')
+    const again = inject('tanstack-start', ctx())
+
+    expect(again).toEqual({ file: 'src/routes/__root.tsx', alreadyInstalled: true })
+    expect(readFileSync(join(cwd, 'src/routes/__root.tsx'), 'utf8')).toBe(once)
+    expect(once.match(/\/oa\.js/g)).toHaveLength(1)
+  })
+
+  it('names the file it looked for when the root route is missing', () => {
+    writeProject({ 'package.json': pkg({ '@tanstack/react-start': '^1.0.0' }) })
+
+    expect(() => inject('tanstack-start', ctx())).toThrow(InjectError)
+    expect(() => inject('tanstack-start', ctx())).toThrow(/src\/routes\/__root\.tsx not found/)
+  })
+
+  it('refuses a root route it cannot anchor in, rather than guessing', () => {
+    writeProject({ 'src/routes/__root.tsx': 'export const Route = somethingElse({})\n' })
+
+    expect(() => inject('tanstack-start', ctx())).toThrow(/Could not find createRootRoute/)
+  })
+})


### PR DESCRIPTION
Closes #4. Rebased onto `main` after #3 merged; three commits: the feature, the injector-scoping fix from CodeRabbit's review, and the `head()` guard from @Uaghazade1's.

**What this changes, and why**

`npx getopen init` in a TanStack Start project misfiled it as "React (Vite / CRA)" — Start is a Vite app with `react` in its dependencies — and then failed looking for an `index.html` Start doesn't have. Now:

- `detect.ts` answers `tanstack-start` from `@tanstack/react-start` (or `@tanstack/solid-start`) in `package.json`, asked before the generic Vite-plus-React question.
- `injectors.ts` gains `injectTanStackStart`: locates the root route's options object from the `Route = createRootRoute…` declaration (falling back to the first call not on an import line), brace-matches its extent past strings and comments, and edits only inside it — the same text-anchored, indentation-matching style as the Nuxt injector, no parser. Three shapes: the tag joins an existing `head()` `scripts` array as its first entry; opens one in a `head()` that has none; or arrives as a whole `head: () => ({ scripts: [...] })` when the root route declares none (`createRootRouteWithContext<T>()({` included). Idempotent on `/oa.js`. A `head` in any form the arrow-object edit cannot see (method shorthand, block body, a named function) is an `InjectError` pointing at the manual guide — never a second `head:` that the person's own would shadow. A missing file, or options object that cannot be found or closed, is likewise an error naming what was looked for.
- The install guide flips to `cliDetects: true` (the page leads with "The short way: `npx getopen init`"), notes the Solid flavour imports the same shape from `@tanstack/solid-router`, and the CLI docs page's detected-frameworks sentence lists TanStack Start.

**How you know it works**

- `tests/unit/cli-init-tanstack-start.test.ts` (new; `detect`/`inject` had no tests before) — 14 cases: detection incl. precedence over Vite+React and the Solid flavour; all three injection shapes; a helper `head()` above the Route and an earlier `({` call (both fail against the unscoped injector); the `app/routes` fallback; idempotence; the method-shorthand / named / block-body `head` refusals; the missing-file and no-anchor errors. Every written file is run through `ts.transpileModule` and asserted diagnostic-free.
- Real CLI end-to-end on scaffolded Start projects: detection without `--framework`, write, "Already installed" on rerun; a fixture with a helper `head()` and an `({` arrow above the Route edits only the Route; a method-shorthand `head()` prints the refusal, exit 1, file untouched.
- `pnpm run verify` passes.

**Anything a reviewer should look at twice**

- `closingBrace()` is a ~40-line scanner that steps over string/template literals and comments — the minimum needed to bound the options object without a parser. A template literal containing a nested backtick inside `${}` would fool it; that is refused (unbalanced → error), not mis-edited.
- Solid Start detection reuses the same injector (identical root-route file and `head()` shape).
- `FrameworkId` grew a member; `inject()`'s `switch` has no default, so the compiler enforced the new case.

---

- [x] `pnpm run verify` passes locally
- [ ] API surface changes start in `packages/contracts/openapi/openapi.yaml` and `pnpm run contracts:generate` was re-run — n/a, no API change
- [ ] Tracker changes still fit the byte budget (`pnpm run tracker:build`) — n/a, no tracker change (verify ran it anyway: within budget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TanStack Start support to CLI initialization.
  * Automatically detects TanStack React Start and Solid Start projects.
  * Configures analytics tracking in supported root-route setups.
  * Prevents duplicate tracking when initialization is repeated.

* **Documentation**
  * Added TanStack Start to the supported framework list and setup guide.
  * Documented React and Solid Start configuration, navigation tracking, and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->